### PR TITLE
Changed setState to use functional argument

### DIFF
--- a/webapp/views/components/layout.jsx
+++ b/webapp/views/components/layout.jsx
@@ -13,7 +13,7 @@ module.exports = withRouter(React.createClass({
   },
   handleClick: function(e){
     e.preventDefault();
-    this.setState({loggedIn: this.state.loggedIn, open: !this.state.open});
+    this.setState((prevState) => ({loggedIn: prevState.loggedIn, open: !prevState.open}));
   },
   logout: function(e){
     e.preventDefault();


### PR DESCRIPTION
Since the `setState()` call on L16 relies on the previous states value in order to determine the next state, and `setState` is async, using the functional argument (which get's passed the previous state) is more reliable.

From React's docs:

> Because this.props and this.state may be updated asynchronously, you should not rely on their values for calculating the next state.

More info on the [State and Lifecycle](https://facebook.github.io/react/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous) page in React's documentation.